### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,6 +2,7 @@
     "tags": [ "ascii", "ABNF", "parsing" ],
     "perl" : "6.c",
     "name" : "US-ASCII",
+    "license" : "Artistic-2.0",
     "version" : "0.1.3",
     "description" : "US-ASCII restricted character classes and related.",
     "authors" : [ "Ron Schmidt" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license